### PR TITLE
adapt the sidebar's options to the user related pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import DashboardLayout from './layouts/DashboardLayout'
 import PersistAuth from './shared/components/Auth/PersistAuth'
 import RequireAuth from './shared/components/Auth/RequireAuth'
 import AuthenticateForm from './shared/components/Auth/AuthenticateForm'
+import RequireAccountOwner from './shared/components/Auth/RequireAccountOwner'
 
 function App () {
   return (
@@ -41,7 +42,7 @@ function App () {
       <Route element={<DashboardLayout/>}>
         <Route path="/home" element={<SearchPosts />} />
         <Route path="/search/posts" element={<SearchPosts />} />
-        <Route path="/profile/:username" element={<PublicProfileComponent />} />
+        <Route path="/users/:username" element={<PublicProfileComponent />} />
         <Route path="/posts/:id" element={<PostDetails />} />
       </Route>
 
@@ -49,6 +50,14 @@ function App () {
         <Route element={<DashboardLayout/>}>
           <Route path="/posts/new" element={<CreatePost />} />
           <Route path="/posts/:id/edit" element={<EditPost />} />
+        </Route>
+      </Route>
+
+      <Route element={<RequireAccountOwner />} >
+        <Route element={<DashboardLayout/>}>
+          <Route path="/users/:username/edit" element={<PublicProfileComponent />} />
+          <Route path="/users/:username/change-password" element={<PublicProfileComponent />} />
+          <Route path="/users/:username/deactivate-account" element={<PublicProfileComponent />} />
         </Route>
       </Route>
 

--- a/src/shared/components/Auth/RequireAccountOwner.jsx
+++ b/src/shared/components/Auth/RequireAccountOwner.jsx
@@ -1,0 +1,16 @@
+import { Outlet, Navigate, useLocation, useParams } from 'react-router-dom'
+import { useAuthStore } from '../../../stores/authStore'
+
+const RequireAccountOwner = () => {
+  const accountUsername = useAuthStore((state) => state.user)
+  const { username: requestedUsername } = useParams()
+  const isAccountOwner = accountUsername === requestedUsername
+  const location = useLocation()
+  return (
+    isAccountOwner
+      ? <Outlet />
+      : <Navigate to='/login' state={{ from: location }} replace />
+  )
+}
+
+export default RequireAccountOwner

--- a/src/shared/components/Navbar/CustomNavbar.jsx
+++ b/src/shared/components/Navbar/CustomNavbar.jsx
@@ -10,7 +10,7 @@ import NavTextButton from './NavTextButton'
 import RequireAuthOnClick from '../Auth/RequireAuthOnClick'
 import NavbarMenu from './NavbarMenu'
 
-const fullNavbarShowsIn = ['/admin', '/search', '/posts', '/profile', '/home']
+const fullNavbarShowsIn = ['/admin', '/search', '/posts', '/users', '/home']
 
 const CustomNavbar = () => {
   const loggedIn = useAuthStore(state => state.isAuth)

--- a/src/shared/components/Navbar/ProfileMenu.jsx
+++ b/src/shared/components/Navbar/ProfileMenu.jsx
@@ -1,15 +1,15 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
-  UserCircleIcon,
-  Cog6ToothIcon,
+  GlobeAmericasIcon,
+  PencilIcon,
   ShieldCheckIcon,
   PowerIcon
 } from '@heroicons/react/24/solid'
 import { Button, Menu, MenuHandler, MenuItem, MenuList, Typography } from '@material-tailwind/react'
 import { useAuthStore } from '../../../stores/authStore'
-import AvatarIcon from '../Icons/AvatarIcon'
 import { ROLES } from '../../../config/constants/roles'
+import ProfileAvatar from '../ProfileAvatar'
 
 const ProfileMenu = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -25,7 +25,7 @@ const ProfileMenu = () => {
     <Menu open={isMenuOpen} handler={toggleMenu} placement="bottom-end">
       <MenuHandler>
         <Button variant='text' className='p-0.5 rounded-full'>
-          <AvatarIcon size="sm" className="w-10 h-10" />
+          <ProfileAvatar size="sm" className="w-10 h-10" />
         </Button>
       </MenuHandler>
       <MenuList className="p-1">
@@ -42,12 +42,12 @@ const ProfileMenu = () => {
           <ul>{roles.map(role => <li key={role}>- {role}</li>)}</ul>
           </MenuItem>
           <hr className="my-1" />
-          <MenuItem className='p-3 flex items-center gap-2' onClick={goTo(`/profile/${username}`)}>
-            <UserCircleIcon className="h-4 w-4" />
-            Ver perfil
+          <MenuItem className='p-3 flex items-center gap-2' onClick={goTo(`/users/${username}`)}>
+            <GlobeAmericasIcon className="h-4 w-4" />
+            Ver perfil público
           </MenuItem>
-          <MenuItem className='p-3 flex items-center gap-2' onClick={goTo(`/profile/${username}/edit`)}>
-            <Cog6ToothIcon className="h-4 w-4" />
+          <MenuItem className='p-3 flex items-center gap-2' onClick={goTo(`/users/${username}/edit`)}>
+            <PencilIcon className="h-4 w-4" />
             Editar perfil
           </MenuItem>
 

--- a/src/shared/components/Navbar/ProfileMenu.jsx
+++ b/src/shared/components/Navbar/ProfileMenu.jsx
@@ -42,7 +42,7 @@ const ProfileMenu = () => {
           <ul>{roles.map(role => <li key={role}>- {role}</li>)}</ul>
           </MenuItem>
           <hr className="my-1" />
-          <MenuItem className='p-3 flex items-center gap-2' onClick={goTo('/profile')}>
+          <MenuItem className='p-3 flex items-center gap-2' onClick={goTo(`/profile/${username}`)}>
             <UserCircleIcon className="h-4 w-4" />
             Ver perfil
           </MenuItem>
@@ -51,7 +51,7 @@ const ProfileMenu = () => {
             Editar perfil
           </MenuItem>
 
-          {roles.length > 1 && <MenuItem className='p-3 flex items-center gap-2' onClick={goTo('/admin')}>
+          {roles.length > 1 && <MenuItem className='p-3 flex items-center gap-2' onClick={goTo('/admin/roles')}>
             <ShieldCheckIcon className="h-4 w-4" />
             Ir al panel {isAdmin ? 'admin' : 'mod'}
           </MenuItem>}

--- a/src/shared/components/ProfileAvatar.jsx
+++ b/src/shared/components/ProfileAvatar.jsx
@@ -1,12 +1,14 @@
 import { Avatar } from '@material-tailwind/react'
-import { useAuthStore } from '../../../stores/authStore'
+import { useAuthStore } from '../../stores/authStore'
+import AvatarIcon from './Icons/AvatarIcon'
 
-const AvatarIcon = ({ size, className }) => {
+const ProfileAvatar = ({ size, className }) => {
   const avatarUrl = useAuthStore(state => state.avatarUrl)
   const username = useAuthStore(state => state.user)
-  avatarUrl
+
+  return avatarUrl
     ? <Avatar src={avatarUrl} alt={username} size={size} className={className}/>
     : (<AvatarIcon size={size} className={`${className || ''}`} />)
 }
 
-export default AvatarIcon
+export default ProfileAvatar

--- a/src/shared/components/Sidebars/Sidebar.jsx
+++ b/src/shared/components/Sidebars/Sidebar.jsx
@@ -1,15 +1,23 @@
+import { useLocation } from 'react-router-dom'
 import { SidebarAdmin } from './SidebarAdmin'
 import SidebarSearch from './SidebarSearch'
-import { useLocation } from 'react-router-dom'
-import { matchesAnyPath } from '../../utils/matchesAnyPath'
+import { SidebarAccount } from './SidebarAccount'
+import { useAuthStore } from '../../../stores/authStore'
+import SidebarHome from './SidebarHome'
 
 export default function Sidebar () {
   const { pathname } = useLocation()
-  if (matchesAnyPath(pathname, ['/home'])) {
+  const username = useAuthStore(state => state.user)
+
+  if (pathname.startsWith('/search')) {
     return <SidebarSearch />
-  } else if (matchesAnyPath(pathname, ['/admin'])) {
+  } else if (username && pathname.startsWith(`/users/${username}`)) {
+    return (<SidebarAccount />)
+  } else if (pathname.startsWith('/users')) {
+    return (<SidebarHome />)
+  } else if (pathname.startsWith('/admin')) {
     return (<SidebarAdmin />)
   } else {
-    return <SidebarSearch />
+    return <SidebarHome />
   }
 }

--- a/src/shared/components/Sidebars/SidebarAccount.jsx
+++ b/src/shared/components/Sidebars/SidebarAccount.jsx
@@ -1,67 +1,64 @@
 import { Link, useLocation } from 'react-router-dom'
+import { useState } from 'react'
 import { List, Card, Typography, Accordion, AccordionBody } from '@material-tailwind/react'
-import { ChevronDownIcon, FlagIcon, ShieldCheckIcon, TagIcon, UserGroupIcon } from '@heroicons/react/24/solid'
+import { ChevronDownIcon, Cog6ToothIcon, GlobeAmericasIcon, PencilIcon, UserCircleIcon } from '@heroicons/react/24/solid'
 import SidebarListItem from './SidebarListItem'
 import SidebarListHeader from './SidebarListHeader'
-import { useState } from 'react'
+import { useAuthStore } from '../../../stores/authStore'
 
-export function SidebarAdmin () {
+export function SidebarAccount () {
   const location = useLocation()
-  const [openReportOptions, setOpenReportOptions] = useState(false)
-  const toggleReportOptions = () => setOpenReportOptions(prevState => !prevState)
+  const username = useAuthStore(state => state.user)
+  const [openAccountOptions, setOpenAccountOptions] = useState(false)
+  const toggleAccountOptions = () => setOpenAccountOptions(prevState => !prevState)
   const showAsSelectedIn = (currPath) => currPath === location.pathname ? 'bg-primary-dark text-accent-light opacity-80' : ''
 
   return (
     <Card shadow={false} className='bg-accent-dark text-grey-dark h-full overflow-x-clip overflow-y-auto'>
       <List className='text-inherit pb-0'>
         <Typography variant="h2" color="blue-gray" className='flex gap-1 items-center text-grey-light mb-3 text-md'>
-          <ShieldCheckIcon width="1.25em" strokeWidth={1} fill="#508DDD" /> Panel de Administrador
+          <UserCircleIcon width="1em" strokeWidth={2} fill="#508DDD" className='w-5 h-5' /> Cuenta
         </Typography>
-        <Link to='/admin/roles'>
+        <Link to={`/users/${username}`}>
           <SidebarListItem>
             <Typography variant="h2" className='flex gap-1 items-center text-grey-light text-md'>
-              <UserGroupIcon width="1em" strokeWidth={2} fill="#508DDD" className='w-5 h-5' /> Gestión de roles
+              <GlobeAmericasIcon width="1em" strokeWidth={2} fill="#508DDD" className='w-5 h-5' /> Ver perfil público
+            </Typography>
+          </SidebarListItem>
+        </Link>
+        <Link to={`/users/${username}/edit`}>
+          <SidebarListItem>
+            <Typography variant="h2" className='flex gap-1 items-center text-grey-light text-md'>
+              <PencilIcon width="1em" strokeWidth={2} fill="#508DDD" className='w-5 h-5' /> Editar perfil
             </Typography>
           </SidebarListItem>
         </Link>
         <Accordion
-          open={openReportOptions}
+          open={openAccountOptions}
           icon={
           <ChevronDownIcon
             strokeWidth={2.5}
-            className={`mx-auto h-4 w-4 text-grey-dark transition-transform ${openReportOptions ? 'rotate-180' : ''}`}
+            className={`mx-auto h-4 w-4 text-grey-dark transition-transform ${openAccountOptions ? 'rotate-180' : ''}`}
           />
         }>
-          <Link to='/admin/reports'>
-            <SidebarListHeader
-                selected={openReportOptions}
-                onClick={toggleReportOptions}
-                className="text-sm"
-                icon={<FlagIcon width="1.25em" strokeWidth={2} fill="#508DDD" />}
-                label="Gestión de reportes"
-              />
-          </Link>
+          <SidebarListHeader
+              selected={openAccountOptions}
+              onClick={toggleAccountOptions}
+              className="text-sm"
+              icon={<Cog6ToothIcon width="1.25em" strokeWidth={2} fill="#508DDD" />}
+              label="Configuración de cuenta"
+            />
           <AccordionBody className="py-1">
             <List className="p-0 text-grey-dark">
-              <Link to='/admin/reports/posts'>
-                <SidebarListItem className={showAsSelectedIn('/admin/reports/posts')}>Reportes de publicaciones</SidebarListItem>
+              <Link to={`/users/${username}/change-password`}>
+                <SidebarListItem className={showAsSelectedIn(`/users/${username}/change-password`)}>Cambiar contraseña</SidebarListItem>
               </Link>
-              <Link to='/admin/reports/comments'>
-                <SidebarListItem className={showAsSelectedIn('/admin/reports/comments')}>Reportes de comentarios</SidebarListItem>
-              </Link>
-              <Link to='/admin/reports/users'>
-                <SidebarListItem className={showAsSelectedIn('/admin/reports/users')}>Reportes de usuarios</SidebarListItem>
+              <Link to={`/users/${username}/deactivate-account`}>
+                <SidebarListItem className={showAsSelectedIn(`/users/${username}/deactivate-account`)}>Desactivar cuenta</SidebarListItem>
               </Link>
             </List>
           </AccordionBody>
         </Accordion>
-        <Link to='/admin/categories'>
-          <SidebarListItem>
-            <Typography variant="h2" className='flex gap-1 items-center text-grey-light text-md'>
-              <TagIcon width="1em" strokeWidth={2} fill="#508DDD" className='w-5 h-5' /> Gestión de categorías
-            </Typography>
-          </SidebarListItem>
-        </Link>
       </List>
     </Card>
   )

--- a/src/shared/components/Sidebars/SidebarHome.jsx
+++ b/src/shared/components/Sidebars/SidebarHome.jsx
@@ -4,11 +4,10 @@ import {
   AccordionHeader,
   AccordionBody
 } from '@material-tailwind/react'
-import { ChevronDownIcon, CodeBracketIcon, AcademicCapIcon } from '@heroicons/react/24/solid'
+import { ChevronDownIcon, CodeBracketIcon, AcademicCapIcon, ArrowTrendingUpIcon } from '@heroicons/react/24/solid'
 import Logo from '../Logo'
 import SidebarListItem from './SidebarListItem'
 import { DEVELOPERS, INSTRUCTORS } from '../../../config/constants/aboutUs'
-import SortIcon from '../Icons/SortIcon'
 import SidebarListHeader from './SidebarListHeader'
 
 export default function SidebarHome () {
@@ -36,10 +35,11 @@ export default function SidebarHome () {
     <Card shadow={false} className='bg-accent-dark text-grey-dark h-full overflow-x-clip overflow-y-auto'>
       <List className='text-inherit pb-0'>
         <Typography variant="h2" className='flex gap-1 items-center text-grey-light mb-3 text-md'>
-          <SortIcon /> Ordenar por
+          <ArrowTrendingUpIcon width="1.7em" strokeWidth={20} fill="#508DDD" />
+          Ver publicaciones
         </Typography>
-        <SidebarListItem onClick={handleDescendente}>Más votados</SidebarListItem>
-        <SidebarListItem onClick={handleAscendente}>Menos votados</SidebarListItem>
+        <SidebarListItem onClick={handleDescendente}>Más votadas</SidebarListItem>
+        <SidebarListItem onClick={handleAscendente}>Más recientes</SidebarListItem>
       </List>
       <hr className='border-primary-dark my-2'/>
       <Accordion

--- a/src/shared/components/Sidebars/SidebarListItem.jsx
+++ b/src/shared/components/Sidebars/SidebarListItem.jsx
@@ -12,13 +12,3 @@ const SidebarListItem = ({ children, onClick: handleClick, className, selected, 
 }
 
 export default SidebarListItem
-/*
-<ListItem
-            className={`text-sm bg-accent-dark transition-all focus:bg-primary-dark hover:bg-primary-dark active:bg-primary-dark focus:text-accent-light  hover:text-accent-light active:text-accent-light focus:opacity-80 hover:opacity-95 active:opacity-80 tracking-wide shadow-md ${className || ''}`}
-            onClick={handleClick}
-            selected={selected}
-            {...otherProps}
-            >
-              {children}
-          </ListItem>)
-          */

--- a/src/shared/utils/matchesAnyPath.js
+++ b/src/shared/utils/matchesAnyPath.js
@@ -3,7 +3,7 @@ const matchesAnyPath = (pathname, pathOrPaths) => {
     return pathname === pathOrPaths
   }
   const allowedPaths = pathOrPaths.join('|')
-  return RegExp(`(${allowedPaths}).*`).test(pathname)
+  return RegExp(`^(${allowedPaths}).*`).test(pathname)
 }
 
 export { matchesAnyPath }


### PR DESCRIPTION
- fix bug that prevented being redirected to the actual user profile
- modify the matchesAnyPath function's regular expression to prevent conflicts between reserved pathnames and usernames
- create a component to filter out users who don't own a requested account
- remove comments from the SidebarListItem component's code
- modify the SidebarHome to show options that make more sense for the routes where it is displayed
- rename /profile routes as /users routes for consistency, fix bug with the avatar component and refactor the code accordingly