### PR TITLE
sort and filter posts on the home page

### DIFF
--- a/src/features/comments/CommentList.jsx
+++ b/src/features/comments/CommentList.jsx
@@ -7,7 +7,6 @@ import { Spinner, Typography } from '@material-tailwind/react'
 const CommentList = ({ postId }) => {
   const getCommentsQuery = useGetComments(postId)
   const comments = handleComments(getCommentsQuery?.data)
-
   if (getCommentsQuery?.isLoading) {
     return (
     <div className='flex justify-center'>
@@ -23,7 +22,7 @@ const CommentList = ({ postId }) => {
   return (
     <div className="p-3 pt-1 pr-5 ">
       {getCommentsQuery.data.length > 0
-        ? getCommentsQuery.data.map(comment =>
+        ? comments.rootComments.map(comment =>
         <Comment
           key={comment.id}
           comment={comment}

--- a/src/features/posts/PostSummary.jsx
+++ b/src/features/posts/PostSummary.jsx
@@ -12,7 +12,7 @@ const PostSummary = ({ post }) => {
   return (
           <Card className=' w-full pt-3'>
             <List className='flex-row gap-1 mx-4'>
-              <Typography variant='small' color='blue-gray' className='font-bold'>
+              <Typography variant='small' className='font-bold text-blue-gray-500'>
                 {post.category}
               </Typography>
               <span className='font-semibold'>&middot;</span>

--- a/src/features/posts/useGetPosts.js
+++ b/src/features/posts/useGetPosts.js
@@ -1,11 +1,18 @@
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { getPosts } from '../../services/posts'
+import { useSearchParams } from 'react-router-dom'
 
 const useGetPosts = () => {
-  return useQuery({
-    queryKey: ['posts'],
-    queryFn: getPosts
-    // select: (data) => data.sort((a, b) => b.id - a.id)
+  const [searchParams] = useSearchParams()
+  const sort = searchParams.get('sort')
+  const order = searchParams.get('order')
+  return useInfiniteQuery({
+    queryKey: ['posts', { sort, order }],
+    queryFn: ({ pageParam }) => getPosts({ sort, order, page: pageParam }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false
   })
 }
 

--- a/src/features/posts/useGetPosts.js
+++ b/src/features/posts/useGetPosts.js
@@ -6,9 +6,10 @@ const useGetPosts = () => {
   const [searchParams] = useSearchParams()
   const sort = searchParams.get('sort')
   const order = searchParams.get('order')
+  const category = searchParams.get('category')
   return useInfiniteQuery({
-    queryKey: ['posts', { sort, order }],
-    queryFn: ({ pageParam }) => getPosts({ sort, order, page: pageParam }),
+    queryKey: ['posts', { sort, order, category }],
+    queryFn: ({ pageParam }) => getPosts({ sort, order, page: pageParam, category }),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => lastPage.nextPage,
     staleTime: 5 * 60 * 1000,

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,23 +1,71 @@
-import { Navigate } from 'react-router-dom'
-import PostList from '../features/posts/PostList'
-import { useGetPosts } from '../features/posts/useGetPosts'
+import { Link } from 'react-router-dom'
 import { useDocumentTitle } from '../shared/hooks/useDocumentTitle'
+import { useGetPosts } from '../features/posts/useGetPosts'
+import PostSummary from '../features/posts/PostSummary'
+import { useCallback, useRef } from 'react'
+import { Spinner } from '@material-tailwind/react'
 
 const Home = () => {
-  const getPostsQuery = useGetPosts()
-  useDocumentTitle('Home - Juniors.tech')
+  useDocumentTitle('Home')
+  const {
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    data,
+    status,
+    error
+  } = useGetPosts()
 
-  if (getPostsQuery.isLoading) {
-    return <h2>Cargando...</h2>
+  const intObserver = useRef()
+  const lastPostRef = useCallback(post => {
+    if (isFetchingNextPage) return
+
+    if (intObserver.current) intObserver.current.disconnect()
+
+    intObserver.current = new IntersectionObserver(posts => {
+      if (posts[0].isIntersecting && hasNextPage) {
+        fetchNextPage()
+      }
+    })
+
+    if (post) intObserver.current.observe(post)
+  }, [isFetchingNextPage, fetchNextPage, hasNextPage])
+
+  if (status === 'loading') {
+    return (
+    <div className='flex justify-center'>
+      <Spinner className="h-16 w-16 text-gray-900/50" />
+    </div>
+    )
   }
 
-  if (getPostsQuery.isError) {
-    return <Navigate to="not-found"/>
+  if (status === 'error') {
+    return <div>Error: {error.message}</div>
   }
+
+  const posts = data?.pages.flatMap(page => page.posts) || []
 
   return (
-    <div className="min-h-screen">
-      <PostList {...getPostsQuery.data} />
+    <div className='min-h-full flex flex-col gap-3 max-w-[48rem] mb-4 mr-4'>
+      {posts.map((post, index, { length }) => {
+        if (index === length - 1) {
+          return (
+          <Link ref={lastPostRef} key={post.id} to={`/posts/${post.id}/${post.slug}`}>
+            <PostSummary post={post} />
+          </Link>
+          )
+        }
+        return (
+          <Link key={post.id} to={`/posts/${post.id}/${post.slug}`}>
+            <PostSummary post={post} />
+          </Link>
+        )
+      })}
+      {isFetchingNextPage && (
+        <div className='flex justify-center'>
+          <Spinner className="h-16 w-16 text-gray-900/50" />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -46,21 +46,27 @@ const Home = () => {
   const posts = data?.pages.flatMap(page => page.posts) || []
 
   return (
-    <div className='min-h-full flex flex-col gap-3 max-w-[48rem] mb-4 mr-4'>
-      {posts.map((post, index, { length }) => {
-        if (index === length - 1) {
+    <div className={`flex flex-col gap-3 mb-4 mr-4 ${posts.length > 0 ? 'max-w-[48rem]' : ''}`}>
+      {posts.length > 0
+        ? posts.map((post, index, { length }) => {
+          if (index === length - 1) {
+            return (
+              <Link ref={lastPostRef} key={post.id} to={`/posts/${post.id}/${post.slug}`}>
+                <PostSummary post={post} />
+              </Link>
+            )
+          }
           return (
-          <Link ref={lastPostRef} key={post.id} to={`/posts/${post.id}/${post.slug}`}>
-            <PostSummary post={post} />
-          </Link>
+            <Link key={post.id} to={`/posts/${post.id}/${post.slug}`}>
+              <PostSummary post={post} />
+            </Link>
           )
-        }
-        return (
-          <Link key={post.id} to={`/posts/${post.id}/${post.slug}`}>
-            <PostSummary post={post} />
-          </Link>
-        )
-      })}
+        })
+        : (<div className='text-center w-full text-lg'>
+            <p>Aún no hay publicaciones en esta categoría.</p>
+            <Link to="/posts/new" className='text-primary-dark font-semibold'>Anímate a crear la primera</Link>
+          </div>)
+    }
       {isFetchingNextPage && (
         <div className='flex justify-center'>
           <Spinner className="h-16 w-16 text-gray-900/50" />

--- a/src/services/posts.js
+++ b/src/services/posts.js
@@ -1,12 +1,13 @@
 import { baseApi } from '../api/baseApi'
 import { API_PATHS } from '../config/constants/apiUrls'
 
-const getPosts = async ({ sort, order, page, limit }) => {
+const getPosts = async ({ sort, order, page, limit, category }) => {
   const params = new URLSearchParams()
   if (sort) params.append('sort', sort)
   if (order) params.append('order', order)
   if (page) params.append('page', page)
   if (limit) params.append('limit', limit)
+  if (category) params.append('category', category)
 
   const { data: { data } } = await baseApi.get(API_PATHS.posts, { params })
   return data

--- a/src/services/posts.js
+++ b/src/services/posts.js
@@ -1,8 +1,14 @@
 import { baseApi } from '../api/baseApi'
 import { API_PATHS } from '../config/constants/apiUrls'
 
-const getPosts = async () => {
-  const { data: { data } } = await baseApi.get(API_PATHS.posts)
+const getPosts = async ({ sort, order, page, limit }) => {
+  const params = new URLSearchParams()
+  if (sort) params.append('sort', sort)
+  if (order) params.append('order', order)
+  if (page) params.append('page', page)
+  if (limit) params.append('limit', limit)
+
+  const { data: { data } } = await baseApi.get(API_PATHS.posts, { params })
   return data
 }
 

--- a/src/shared/components/Sidebars/SidebarHome.jsx
+++ b/src/shared/components/Sidebars/SidebarHome.jsx
@@ -19,6 +19,7 @@ import SidebarListItem from './SidebarListItem'
 import { DEVELOPERS, INSTRUCTORS } from '../../../config/constants/aboutUs'
 import SidebarListHeader from './SidebarListHeader'
 import { useSearchParams } from 'react-router-dom'
+import SidebarPostFilteringOptions from './SidebarPostFilteringOptions'
 
 export default function SidebarHome () {
   const [, setSearchParams] = useSearchParams()
@@ -55,6 +56,8 @@ export default function SidebarHome () {
         <SidebarListItem onClick={handleSortingOptionChange('votes', 'desc')}>Más votadas</SidebarListItem>
         <SidebarListItem onClick={handleSortingOptionChange('date', 'asc')}>Más recientes</SidebarListItem>
       </List>
+      <hr className='border-primary-dark my-2'/>
+      <SidebarPostFilteringOptions />
       <hr className='border-primary-dark my-2'/>
       <Accordion
         open={isOpen('junior')}

--- a/src/shared/components/Sidebars/SidebarHome.jsx
+++ b/src/shared/components/Sidebars/SidebarHome.jsx
@@ -1,27 +1,41 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import {
-  List, ListItem, Card, Typography, Accordion,
+  List,
+  ListItem,
+  Card,
+  Typography,
+  Accordion,
   AccordionHeader,
   AccordionBody
 } from '@material-tailwind/react'
-import { ChevronDownIcon, CodeBracketIcon, AcademicCapIcon, ArrowTrendingUpIcon } from '@heroicons/react/24/solid'
+import {
+  ChevronDownIcon,
+  CodeBracketIcon,
+  AcademicCapIcon,
+  ArrowTrendingUpIcon
+} from '@heroicons/react/24/solid'
 import Logo from '../Logo'
 import SidebarListItem from './SidebarListItem'
 import { DEVELOPERS, INSTRUCTORS } from '../../../config/constants/aboutUs'
 import SidebarListHeader from './SidebarListHeader'
+import { useSearchParams } from 'react-router-dom'
 
 export default function SidebarHome () {
-  /* eslint-disable no-unused-vars */
-  const [orderDirection, setOrderDirection] = useState('desc')
-  // const [orderBy, setOrderBy] = useState('voteCount')
-  const [open, setOpen] = React.useState({
+  const [, setSearchParams] = useSearchParams()
+  const [open, setOpen] = useState({
     junior: false,
     dev: false,
     instructor: false
   })
-  const handleAscendente = () => setOrderDirection('asc')
-  const handleDescendente = () => setOrderDirection('desc')
-  // const handleOrderChange = (field) => setOrderBy(field)
+
+  const handleSortingOptionChange = (sort, order) => () => {
+    setSearchParams((prevSearchParams) => {
+      const newSearchParams = new URLSearchParams(prevSearchParams)
+      newSearchParams.set('sort', sort)
+      newSearchParams.set('order', order)
+      return newSearchParams
+    })
+  }
 
   const toggleOpen = (key) => () => {
     setOpen(prevState => ({
@@ -38,8 +52,8 @@ export default function SidebarHome () {
           <ArrowTrendingUpIcon width="1.7em" strokeWidth={20} fill="#508DDD" />
           Ver publicaciones
         </Typography>
-        <SidebarListItem onClick={handleDescendente}>Más votadas</SidebarListItem>
-        <SidebarListItem onClick={handleAscendente}>Más recientes</SidebarListItem>
+        <SidebarListItem onClick={handleSortingOptionChange('votes', 'desc')}>Más votadas</SidebarListItem>
+        <SidebarListItem onClick={handleSortingOptionChange('date', 'asc')}>Más recientes</SidebarListItem>
       </List>
       <hr className='border-primary-dark my-2'/>
       <Accordion

--- a/src/shared/components/Sidebars/SidebarPostFilteringOptions.jsx
+++ b/src/shared/components/Sidebars/SidebarPostFilteringOptions.jsx
@@ -30,7 +30,7 @@ const SidebarPostFilteringOptions = () => {
         <div className='flex items-center justify-between mb-3 pr-3'>
           <Typography variant="h2" className='flex gap-1 items-center text-grey-light text-md'>
           <FunnelIcon width="1em" strokeWidth={2.5} stroke="#508DDD" className='w-5 h-5' />
-            Buscar sobre
+            Filtrar por
           </Typography>
           {category && (
         <Button


### PR DESCRIPTION
- change the category color in the summary card
- change the getPosts service function to support sorting and pagination
- change the query params from the home sidebar
- implement an inifinite scroll navigation on the home page
- change the post filters section's title to make it more reusable
- implement the filter posts by category from the home page's sidebar
- filter the posts on the home page by category